### PR TITLE
Fix incorrect and inconsistent addressing modes

### DIFF
--- a/src/main/java/fi/helsinki/cs/titokone/Compiler.java
+++ b/src/main/java/fi/helsinki/cs/titokone/Compiler.java
@@ -959,6 +959,13 @@ public class Compiler {
                                 lineAsArray[lineAsArrayIndex].indexOf("(") + 1,
                                 lineAsArray[lineAsArrayIndex].indexOf(")")
                         );
+
+                        if (symbolicInterpreter.getRegisterId(secondRegister) == -1) {
+                            comment = new Message("Compilation failed: {0}",
+                                    new Message("invalid register {0}.",
+                                            secondRegister).toString()).toString();
+                            throw new TTK91CompileException(comment);
+                        }
                     }
                 }
             }

--- a/src/main/java/fi/helsinki/cs/titokone/Compiler.java
+++ b/src/main/java/fi/helsinki/cs/titokone/Compiler.java
@@ -867,16 +867,6 @@ public class Compiler {
             }
         }
 
-
-        // Now supports addressing mode LOAD R1, (R2),
-        // which is equal to LOAD R1, 0(R2).
-        // 5.10.2004, Tom Bertell
-        if (lineAsArrayIndex < lineAsArray.length) {
-            if (lineAsArray[lineAsArrayIndex].charAt(0) == '(') {
-                lineAsArray[lineAsArrayIndex] = '0' + lineAsArray[lineAsArrayIndex];
-            }
-        }
-
         /* addressingMode */
         if (lineAsArrayIndex < lineAsArray.length) {
             if (lineAsArray[lineAsArrayIndex].charAt(0) == '=' ||
@@ -914,6 +904,12 @@ public class Compiler {
                                 addressingMode.length(),
                                 lineAsArray[lineAsArrayIndex].indexOf("(")
                         );
+                    }
+
+                    // if there was no address before parentheses, it's the same as having 0 there
+                    // LOAD R1, (R2)
+                    if (address.isEmpty()) {
+                        address = "0";
                     }
 
                     secondRegister = lineAsArray[lineAsArrayIndex].substring(

--- a/src/main/java/fi/helsinki/cs/titokone/Compiler.java
+++ b/src/main/java/fi/helsinki/cs/titokone/Compiler.java
@@ -868,12 +868,11 @@ public class Compiler {
         }
 
 
-        // Now supports addressing mode LOAD/STORE R1, (R2),
-        // which is equal to LOAD/STORE R1, 0(R2).
+        // Now supports addressing mode LOAD R1, (R2),
+        // which is equal to LOAD R1, 0(R2).
         // 5.10.2004, Tom Bertell
         if (lineAsArrayIndex < lineAsArray.length) {
-            if (lineAsArray[lineAsArrayIndex].charAt(0) == '(' &&
-                    (opcode.equalsIgnoreCase("store") || opcode.equalsIgnoreCase("load"))) {
+            if (lineAsArray[lineAsArrayIndex].charAt(0) == '(') {
                 lineAsArray[lineAsArrayIndex] = '0' + lineAsArray[lineAsArrayIndex];
             }
         }

--- a/src/main/java/fi/helsinki/cs/titokone/SymbolicInterpreter.java
+++ b/src/main/java/fi/helsinki/cs/titokone/SymbolicInterpreter.java
@@ -163,9 +163,16 @@ public class SymbolicInterpreter extends Interpreter {
             // if store or jump then addressinmode as int -= 1;
             if (opcodeAsInt == 1 ||
                     (opcodeAsInt >= 32 && opcodeAsInt <= 44) ||
-                    (addressEmpty && !otherRegister.equals("")) ||
                     opcodeAsInt == 49
                     ) {
+                addressingModeAsInt = addressingModeAsInt - 1;
+                if (addressingModeAsInt == -1) {
+                    ++addressingModeAsInt;
+                }
+            }
+
+            // if second operand is only register, then addressing mode as int -= 1
+            if (addressEmpty && !otherRegister.equals("")) {
                 addressingModeAsInt = addressingModeAsInt - 1;
                 if (addressingModeAsInt == -1) {
                     ++addressingModeAsInt;


### PR DESCRIPTION
Fixes the addressing modes for different instruction syntaxes. They are now as follows:
```
load R2, R1         ; 0
load R2, @R1        ; 1

load R2, =(R1)      ; 0 ; previously did not compile
load R2, (R1)       ; 1
add R2, (R1)        ; 1 ; previously 0
load R2, @(R1)      ; 2 ; previously 1

load R2, =0(R1)     ; 0
load R2, 0(R1)      ; 1
load R2, @0(R1)     ; 2

load R2, =0         ; 0
load R2, 0          ; 1
load R2, @0         ; 2


store R1, @R2       ; 0 ; previously 1

store R1, (R2)      ; 0
store R1, @(R2)     ; 1

store R1, 0(R2)     ; 0
store R1, @0(R2)    ; 1

store R1, 0         ; 0
store R1, @0        ; 1
```
Also fixes a bug where compilation might succeed even if a register was invalid.
See commit messages for more info.